### PR TITLE
Add Tauri UI example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,30 @@ También puedes utilizar `make_executable.py` para simplificar la generación de
 ```bash
 python make_executable.py
 ```
+
+
+## Frontend multiplataforma con Tauri
+
+Se incluye un ejemplo mínimo de interfaz creada con **Tauri** en la carpeta `ui/tauri`.
+Esta UI consume la API REST de `wifi_fix.server` y permite ejecutar las acciones
+principales desde una ventana nativa.
+
+Tauri permite usar tecnologías web modernas y genera binarios ligeros y seguros.
+Si se requiere un ecosistema de librerías web más amplio se podría usar
+**Electron**, aunque el tamaño final sería mayor.
+
+Para probar la interfaz Tauri primero inicia el servidor FastAPI:
+
+```bash
+uvicorn wifi_fix.server:app --reload
+```
+
+Luego, dentro de `ui/tauri/src-tauri`, compila y ejecuta la aplicación
+(requiere Rust y las herramientas de Tauri instaladas):
+
+```bash
+cargo tauri dev
+```
+
+La UI se inspira en apps como Notion o Linear: tipografía limpia, colores
+neutros con toques de acento, espaciado generoso y soporte de modo oscuro.

--- a/ui/tauri/src-tauri/Cargo.toml
+++ b/ui/tauri/src-tauri/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "wifi_fix_ui"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tauri = { version = "1", features = ["api-all"] }
+

--- a/ui/tauri/src-tauri/src/main.rs
+++ b/ui/tauri/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+fn main() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/ui/tauri/src-tauri/tauri.conf.json
+++ b/ui/tauri/src-tauri/tauri.conf.json
@@ -1,0 +1,21 @@
+{
+  "build": {
+    "beforeBuildCommand": "",
+    "beforeDevCommand": "",
+    "devPath": "../src",
+    "distDir": "../src"
+  },
+  "package": {
+    "productName": "WiFi Fix UI",
+    "version": "0.1.0"
+  },
+  "tauri": {
+    "windows": [
+      {
+        "title": "WiFi Fixer",
+        "width": 800,
+        "height": 600
+      }
+    ]
+  }
+}

--- a/ui/tauri/src/index.html
+++ b/ui/tauri/src/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WiFi Fixer</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <h1>WiFi Fixer</h1>
+    <div class="actions">
+      <button onclick="callFixAll()">Arreglar todo</button>
+      <button onclick="callDiagnose()">Diagnóstico</button>
+    </div>
+    <pre id="output"></pre>
+  </div>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/ui/tauri/src/main.js
+++ b/ui/tauri/src/main.js
@@ -1,0 +1,11 @@
+async function callFixAll() {
+  const res = await fetch('http://localhost:8000/fix_all', { method: 'POST' });
+  const data = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+}
+
+async function callDiagnose() {
+  const res = await fetch('http://localhost:8000/diagnose');
+  const data = await res.json();
+  document.getElementById('output').textContent = JSON.stringify(data, null, 2);
+}

--- a/ui/tauri/src/style.css
+++ b/ui/tauri/src/style.css
@@ -1,0 +1,47 @@
+:root {
+  --bg: #f5f5f5;
+  --fg: #1a1a1a;
+  --accent: #0055ff;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #1a1a1a;
+    --fg: #f5f5f5;
+    --accent: #66aaff;
+  }
+}
+body {
+  font-family: system-ui, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+  margin: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+.actions button {
+  margin: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.1s ease-in-out;
+}
+.actions button:hover {
+  transform: translateY(-2px);
+}
+pre {
+  text-align: left;
+  white-space: pre-wrap;
+  background: rgba(0,0,0,0.05);
+  padding: 1rem;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- add minimal Tauri frontend under `ui/tauri`
- document how to run the Tauri UI in the README

## Testing
- `python -m py_compile wifi_fix/*.py wifi_fix_tool.py make_executable.py`
