### PR TITLE
Add React/Vite frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Node
+node_modules/
+dist/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Misc
+*.log
+.vscode/
+.env

--- a/README.md
+++ b/README.md
@@ -77,3 +77,17 @@ cargo tauri dev
 
 La UI se inspira en apps como Notion o Linear: tipografía limpia, colores
 neutros con toques de acento, espaciado generoso y soporte de modo oscuro.
+
+## Frontend web con React y Vite
+
+Se incluye una interfaz web desarrollada con **React** y **Vite** en la carpeta `ui/react-vite`. Esta interfaz utiliza el mismo estilo sobrio que la versión Tauri (inspirado en Notion/Linear/Raycast) y consume la API REST proporcionada por `wifi_fix.server`.
+
+Para probarla es necesario instalar las dependencias de Node y luego ejecutar Vite:
+
+```bash
+cd ui/react-vite
+npm install
+npm run dev
+```
+
+Por defecto la aplicación se sirve en `http://localhost:5173` y espera que la API de FastAPI esté disponible en `http://localhost:8000`.

--- a/ui/react-vite/README.md
+++ b/ui/react-vite/README.md
@@ -1,0 +1,14 @@
+# React/Vite UI
+
+Esta carpeta contiene una interfaz web creada con [React](https://react.dev) y [Vite](https://vitejs.dev) que se comunica con la API REST de `wifi_fix.server`.
+
+```bash
+# Iniciar el servidor FastAPI en otra consola
+uvicorn wifi_fix.server:app --reload
+
+# Instalar dependencias y lanzar Vite
+npm install
+npm run dev
+```
+
+La aplicación se inspira en el estilo de Notion, Linear y Raycast: modo oscuro por defecto, tipografía moderna y colores neutros con un toque de acento.

--- a/ui/react-vite/index.html
+++ b/ui/react-vite/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WiFi Fixer</title>
+    <script type="module" src="/src/main.jsx"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/ui/react-vite/package.json
+++ b/ui/react-vite/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "wifi-fixer-react",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.0.0",
+    "@vitejs/plugin-react": "^4.0.0"
+  }
+}

--- a/ui/react-vite/src/App.css
+++ b/ui/react-vite/src/App.css
@@ -1,0 +1,1 @@
+/* App specific styles can go here */

--- a/ui/react-vite/src/App.jsx
+++ b/ui/react-vite/src/App.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+import './App.css';
+
+function App() {
+  const [output, setOutput] = useState('');
+
+  async function callFixAll() {
+    const res = await fetch('http://localhost:8000/fix_all', { method: 'POST' });
+    const data = await res.json();
+    setOutput(JSON.stringify(data, null, 2));
+  }
+
+  async function callDiagnose() {
+    const res = await fetch('http://localhost:8000/diagnose');
+    const data = await res.json();
+    setOutput(JSON.stringify(data, null, 2));
+  }
+
+  return (
+    <div className="container">
+      <h1>WiFi Fixer</h1>
+      <div className="actions">
+        <button onClick={callFixAll}>Arreglar todo</button>
+        <button onClick={callDiagnose}>Diagnóstico</button>
+      </div>
+      <pre>{output}</pre>
+    </div>
+  );
+}
+
+export default App;

--- a/ui/react-vite/src/index.css
+++ b/ui/react-vite/src/index.css
@@ -1,0 +1,47 @@
+:root {
+  --bg: #1a1a1a;
+  --fg: #f5f5f5;
+  --accent: #4d96ff;
+  font-family: 'Inter', system-ui, sans-serif;
+  line-height: 1.5;
+  color-scheme: dark light;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--fg);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.container {
+  text-align: center;
+  padding: 2rem;
+}
+
+.actions button {
+  margin: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  font-size: 1rem;
+  border: none;
+  border-radius: 4px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: transform 0.1s ease-in-out;
+}
+
+.actions button:hover {
+  transform: translateY(-2px);
+}
+
+pre {
+  text-align: left;
+  white-space: pre-wrap;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1rem;
+  border-radius: 4px;
+}

--- a/ui/react-vite/src/main.jsx
+++ b/ui/react-vite/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/ui/react-vite/vite.config.js
+++ b/ui/react-vite/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- add a new React interface built with Vite
- document how to run the Vite frontend
- ignore node_modules and other common temporary files

## Testing
- `python -m py_compile wifi_fix/*.py wifi_fix_tool.py`
- `pytest -q`
