### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Build and Release Binaries
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build dependencies
+        run: pip install pyinstaller
+
+      - name: Build executable
+        run: python make_executable.py
+
+      - name: Upload binary to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ También puedes utilizar `make_executable.py` para simplificar la generación de
 python make_executable.py
 ```
 
+## Descargas
+
+Los binarios listos para usar se publican en la sección **Releases** del
+repositorio en GitHub. Cada vez que se crea una nueva versión, un flujo de
+trabajo de GitHub Actions compila automáticamente el ejecutable con
+PyInstaller para Windows, macOS y Linux y adjunta los archivos resultantes al
+release correspondiente.
+
+Allí podrás descargar el ejecutable para tu sistema sin necesidad de instalar
+Python ni dependencias adicionales.
+
 ## Actualizaciones automáticas
 
 La carpeta `updater/` contiene funciones para comprobar si existen nuevas


### PR DESCRIPTION
## Summary
- automate building PyInstaller binaries on Release events
- add downloads section to README describing release binaries

## Testing
- `python -m py_compile $(git ls-files '*.py')`
