### PR TITLE
Fix GitHub release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -31,6 +33,4 @@ jobs:
           files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-permissions:
-  contents: write  
 


### PR DESCRIPTION
## Summary
- ensure GitHub Actions job has write access to release assets

## Testing
- `python -m py_compile $(git ls-files '*.py')`
