### PR TITLE
Add driver reload feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WiFi Fixer Tool
 
-Esta aplicación de escritorio diagnostica y soluciona problemas de conectividad WiFi y de red en Windows, macOS y Linux. Incluye comprobaciones de gateway, detección de conflictos de IP, verificación de DHCP y test de puertos.
+Esta aplicación de escritorio diagnostica y soluciona problemas de conectividad WiFi y de red en Windows, macOS y Linux. Incluye comprobaciones de gateway, detección de conflictos de IP, verificación de DHCP y test de puertos. Ahora también intenta reinstalar el driver del adaptador cuando es necesario.
 
 ## Estructura del proyecto
 
@@ -11,6 +11,7 @@ El código se organiza como un paquete Python llamado `wifi_fix` que contiene:
 - **logger.py**: generación de reportes en `wifi_fix_report.txt`.
 - **gui_tkinter.py**: interfaz gráfica simple para escritorio.
 - **server.py**: servicio opcional FastAPI para exponer la lógica a otras interfaces (por ejemplo Tauri/Electron).
+- **reload_driver**: función añadida para reinstalar el driver del adaptador WiFi en caso de fallos.
 
 El script `wifi_fix_tool.py` ejecuta la interfaz Tkinter por defecto.
 

--- a/wifi_fix/core.py
+++ b/wifi_fix/core.py
@@ -67,6 +67,12 @@ class WiFiFixCore:
         self.logger.flush()
         return success
 
+    def reload_driver(self):
+        success, output = system.reload_driver()
+        self.logger.log("Reinstalar driver", success, output)
+        self.logger.flush()
+        return success
+
     def check_connection(self):
         os_name = platform.system()
         cmd = ["ping", "-c", "1", "8.8.8.8"] if os_name != "Windows" else ["ping", "-n", "1", "8.8.8.8"]
@@ -187,6 +193,7 @@ class WiFiFixCore:
 
     def fix_all(self):
         self.restart_adapter()
+        self.reload_driver()
         self.renew_ip()
         self.flush_dns()
         self.change_dns()

--- a/wifi_fix/gui_tkinter.py
+++ b/wifi_fix/gui_tkinter.py
@@ -22,6 +22,7 @@ class WiFiFixerApp:
         tk.Button(root, text="Renovar IP", command=self.renew_ip).pack(pady=5)
         tk.Button(root, text="Limpiar DNS", command=self.flush_dns).pack(pady=5)
         tk.Button(root, text="Cambiar DNS", command=self.change_dns).pack(pady=5)
+        tk.Button(root, text="Reinstalar driver", command=self.reload_driver).pack(pady=5)
         tk.Button(root, text="Diagnóstico avanzado", command=self.diagnose_network).pack(pady=5)
         tk.Button(root, text="Arreglar todo", command=self.fix_all, bg="lightgreen").pack(pady=10)
         tk.Button(root, text="Abrir reporte", command=self.open_report).pack(pady=5)
@@ -61,6 +62,10 @@ class WiFiFixerApp:
     def change_dns(self):
         success = self.core.change_dns()
         messagebox.showinfo("Cambiar DNS", "Completado" if success else "Hubo errores")
+
+    def reload_driver(self):
+        success = self.core.reload_driver()
+        messagebox.showinfo("Reinstalar driver", "Completado" if success else "Hubo errores")
 
     def diagnose_network(self):
         self.core.diagnose_network()

--- a/wifi_fix/server.py
+++ b/wifi_fix/server.py
@@ -19,6 +19,12 @@ async def fix_all():
     return {"success": success}
 
 
+@app.post("/reload_driver", response_model=FixResponse)
+async def reload_driver():
+    success = core.reload_driver()
+    return {"success": success}
+
+
 class DiagnoseResponse(BaseModel):
     connection: bool
     gateway: bool

--- a/wifi_fix/system.py
+++ b/wifi_fix/system.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import subprocess
 
@@ -56,3 +57,28 @@ def get_interface():
     if os_name == "Darwin":
         return get_macos_interface()
     return get_linux_interface()
+
+
+def get_linux_driver(interface: str) -> str:
+    """Return the kernel module used by the interface if possible."""
+    try:
+        path = os.path.join("/sys/class/net", interface, "device", "driver")
+        link = os.readlink(path)
+        return os.path.basename(link)
+    except OSError:
+        return ""
+
+
+def reload_driver():
+    """Attempt to reload the WiFi driver for the active interface."""
+    os_name = platform.system()
+    iface = get_interface()
+    if os_name == "Windows":
+        commands = [["pnputil", "/scan-devices"]]
+    elif os_name == "Darwin":
+        commands = [["sudo", "kextunload", "-b", "com.apple.driver.Apple80211"],
+                    ["sudo", "kextload", "-b", "com.apple.driver.Apple80211"]]
+    else:
+        driver = get_linux_driver(iface) or "iwlwifi"
+        commands = [["sudo", "modprobe", "-r", driver], ["sudo", "modprobe", driver]]
+    return run_commands(commands)


### PR DESCRIPTION
## Summary
- support reloading WiFi drivers on all platforms
- expose driver reload in `WiFiFixCore` and add to `fix_all`
- update GUI with a 'Reinstalar driver' button
- expose `/reload_driver` endpoint in the FastAPI server
- document new feature in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`